### PR TITLE
Install `sudo` command first of all

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install sudo command
+  apt:
+    pkg: sudo
+    state: present
+
 - name: Create group for system administration
   group:
     name: "{{ sys_admin_group }}"


### PR DESCRIPTION
We need the sudo command to run some commands like install system
packages.
In some Scaleway instances it is not installed.