### PR TITLE
Feat/unique user

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ With this role you can:
 * Create system administrator users
 * Remove system administrator users
 * Add `sudo` permissions to system administrator users
+* Add multiple ssh keys to a single system administrator user
 
 This role need be runned with `sudo` access.
 
@@ -41,11 +42,24 @@ System Administrators vars:
 
 ### `sys_admin_group`
 
-The name of the system adnimistrators group
+The name of the system administrators group
 
 ```yaml
 sys_admin_group: sysadmin-group
 ``` 
+
+## Single user mode
+When you are restricted to a single user, you must set the `sysadmin_multi_user` variable to `false` and set the `sysadmin_user` variable with the user name. The user must be already created on the server with root privileges.
+
+This will iterate over the `sys_admins` list and add each user key to the authorized keys for the user defined in `sysadmin_user` variable.
+
+This mode is disabled by default.
+
+  ```yaml
+  sysadmin_multi_user: false
+  sysadmin_user: "sysadmin"
+  ```
+
 Example Playbook
 ----------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for sys-admins
+sysadmin_multi_user: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,34 +1,14 @@
 ---
-- name: Install sudo command
-  apt:
-    pkg: sudo
-    state: present
+- import_tasks: multiuser.yml
+  when: sysadmin_multi_user
 
-- name: Create group for system administration
-  group:
-    name: "{{ sys_admin_group }}"
-    state: present
+- import_tasks: singleuser.yml
+  when: not sysadmin_multi_user
 
-- name: Create users for system administration
-  user:
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
-    shell: "/bin/bash"
-    groups: "{{ sys_admin_group }}"
-    append: yes
-  with_items: "{{ sys_admins }}"
-
-- name: Add SSH public keys to system administrators
-  authorized_key:
-    user: "{{ item.name }}"
-    key: "{{ lookup('file', item.ssh_key) }}"
-    state: "{{ item.state }}"
-  when: item.state == "present"
-  with_items: "{{ sys_admins }}"
-
-- name: Copy sudoers configuration for system administrators
-  template:
-    src: sudoers.j2
-    dest: "/etc/sudoers.d/90-sys-admins"
-    mode: 0440
-    group: "{{ sys_admin_group }}"
+- name: Fail if multiusers vars are not not set
+  fail:
+    msg: "sysadmin_multi_user must be set to true or false. If false, sysadmin_username must be set."
+  when:
+  - sysadmin_multi_user is not defined
+  - sysadmin_multi_user is not boolean
+  - sysadmin_multi_user is false and sysadmin_username is not defined

--- a/tasks/multiuser.yml
+++ b/tasks/multiuser.yml
@@ -1,0 +1,34 @@
+---
+- name: Install sudo command
+  apt:
+    pkg: sudo
+    state: present
+
+- name: Create group for system administration
+  group:
+    name: "{{ sys_admin_group }}"
+    state: present
+
+- name: Create users for system administration
+  user:
+    name: "{{ item.name }}"
+    state: "{{ item.state }}"
+    shell: "/bin/bash"
+    groups: "{{ sys_admin_group }}"
+    append: yes
+  with_items: "{{ sys_admins }}"
+
+- name: Add SSH public keys to system administrators
+  authorized_key:
+    user: "{{ item.name }}"
+    key: "{{ lookup('file', item.ssh_key) }}"
+    state: "{{ item.state }}"
+  when: item.state == "present"
+  with_items: "{{ sys_admins }}"
+
+- name: Copy sudoers configuration for system administrators
+  template:
+    src: sudoers.j2
+    dest: "/etc/sudoers.d/90-sys-admins"
+    mode: 0440
+    group: "{{ sys_admin_group }}"

--- a/tasks/singleuser.yml
+++ b/tasks/singleuser.yml
@@ -1,0 +1,13 @@
+---
+- name: Install sudo command
+  apt:
+    pkg: sudo
+    state: present
+
+- name: Add SSH public keys to system administrators
+  authorized_key:
+    user: "{{ sysadmin_username }}"
+    key: "{{ lookup('file', item.ssh_key) }}"
+    state: "{{ item.state }}"
+  when: item.state == "present"
+  with_items: "{{ sys_admins }}"


### PR DESCRIPTION
- [X] Added the boolean `sysadmin_multi_user` variable to choose the right task file to import
- [X] Added the checks for `sysadmin_multi_user` and `sysadmin_username` at the end of `main` tasks.
- [X] Split the logic onto two separate workflows: single user and multi user.
- [X] Add docs to README.md

Note that the single-user mode does not create the user, it must exist before role execution.